### PR TITLE
Make lavender grab client.configuration from the server (using DEFAULT_API_URL)

### DIFF
--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -116,7 +116,7 @@ class Lifecycle {
 
     let useBaseConfig = !CONFIGURATION.REQUEST_CONFIG;
 
-    if (CONFIGURATION.REQUEST_CONFIG) {
+    if (!useBaseConfig) {
       fetch(CONFIGURATION.DEFAULT_API_URL).then(response => {
         if (!response.ok)
           throw new Error(response.statusText);

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -135,8 +135,6 @@ class Lifecycle {
         }
 
         this.client.configuration = conf;
-
-        console.log(conf);
       }).catch(error => {
         console.error(error);
 

--- a/packages/client/components/client/Controller.ts
+++ b/packages/client/components/client/Controller.ts
@@ -1,3 +1,5 @@
+/* eslint-disable require-jsdoc */
+// Above comment removes annoyingness
 import { Accessor, Setter, createSignal } from "solid-js";
 
 import { detect } from "detect-browser";
@@ -112,27 +114,59 @@ class Lifecycle {
       debug: import.meta.env.DEV,
     });
 
-    this.client.configuration = {
-      revolt: String(),
-      app: String(),
-      build: {} as never,
-      features: {
-        autumn: {
-          enabled: true,
-          url: CONFIGURATION.DEFAULT_MEDIA_URL,
+    let useBaseConfig = !CONFIGURATION.REQUEST_CONFIG;
+
+    if (CONFIGURATION.REQUEST_CONFIG) {
+      fetch(CONFIGURATION.DEFAULT_API_URL).then(response => {
+        if (!response.ok)
+          throw new Error(response.statusText);
+
+        return response.json();
+      }).then(conf => {
+        // TODO: swap these around (not in revolt land anymore)
+        if (!conf.features.january) {
+          conf.features.january = conf.features.dove;
+          delete conf.features.dove;
+        }
+
+        if (!conf.features.autumn) {
+          conf.features.autumn = conf.features.pigeon;
+          delete conf.features.pigeon;
+        }
+
+        this.client.configuration = conf;
+
+        console.log(conf);
+      }).catch(error => {
+        console.error(error);
+
+        useBaseConfig = true;
+      });
+    }
+    
+    if (useBaseConfig) {
+        this.client.configuration = {
+        revolt: String(),
+        app: String(),
+        build: {} as never,
+        features: {
+          autumn: {
+            enabled: true,
+            url: CONFIGURATION.DEFAULT_MEDIA_URL,
+          },
+          january: {
+            enabled: true,
+            url: CONFIGURATION.DEFAULT_PROXY_URL,
+          },
+          captcha: {} as never,
+          email: true,
+          invite_only: CONFIGURATION.INVITE_ONLY,
+          voso: {} as never,
         },
-        january: {
-          enabled: true,
-          url: CONFIGURATION.DEFAULT_PROXY_URL,
-        },
-        captcha: {} as never,
-        email: true,
-        invite_only: CONFIGURATION.INVITE_ONLY,
-        voso: {} as never,
-      },
-      vapid: String(),
-      ws: CONFIGURATION.DEFAULT_WS_URL,
-    };
+        vapid: String(),
+        ws: CONFIGURATION.DEFAULT_WS_URL,
+      };
+    }
 
     this.client.events.on("state", this.onState);
     this.client.on("ready", this.onReady);

--- a/packages/client/components/common/lib/env.ts
+++ b/packages/client/components/common/lib/env.ts
@@ -1,6 +1,6 @@
 export default {
   /**
-   * Determines whether or not Lavender will request the servers config
+   * Determines whether or not Lavender will request the server's config
   */
   REQUEST_CONFIG: (import.meta.env.VITE_REQUEST_CONFIG as boolean) ?? true,
 

--- a/packages/client/components/common/lib/env.ts
+++ b/packages/client/components/common/lib/env.ts
@@ -1,32 +1,37 @@
 export default {
   /**
+   * Determines whether or not Lavender will request the servers config
+  */
+  REQUEST_CONFIG: (import.meta.env.VITE_REQUEST_CONFIG as boolean) ?? true,
+
+  /**
    * What API server to connect to by default.
    */
   DEFAULT_API_URL:
     (import.meta.env.DEV ? import.meta.env.VITE_DEV_API_URL : undefined) ??
     (import.meta.env.VITE_API_URL as string) ??
-    "https://revolt.chat/api",
+    "https://web.upryzing.app/api",
   /**
    * What WS server to connect to by default.
    */
   DEFAULT_WS_URL:
     (import.meta.env.DEV ? import.meta.env.VITE_DEV_WS_URL : undefined) ??
     (import.meta.env.VITE_WS_URL as string) ??
-    "wss://revolt.chat/events",
+    "wss://web.upryzing.app/events",
   /**
    * What media server to connect to by default.
    */
   DEFAULT_MEDIA_URL:
     (import.meta.env.DEV ? import.meta.env.VITE_DEV_WS_URL : undefined) ??
-    (import.meta.env.VITE_WS_URL as string) ??
-    "https://autumn.revolt.chat",
+    (import.meta.env.VITE_MEDIA_URL as string) ??
+    "https://web.upryzing.app/pigeon",
   /**
    * What proxy server to connect to by default.
    */
   DEFAULT_PROXY_URL:
     (import.meta.env.DEV ? import.meta.env.VITE_DEV_WS_URL : undefined) ??
-    (import.meta.env.VITE_WS_URL as string) ??
-    "https://jan.revolt.chat",
+    (import.meta.env.VITE_PROXY_URL as string) ??
+    "https://web.upryzing.app/dove",
   /**
    * hCaptcha site key to use if enabled
    */


### PR DESCRIPTION
Currently uses the old boring names from Revolt as I can't figure out how to change it (damn you oapi tool).

In the event it fails (or is disabled using an environment variable), it falls back to the older behaviour.

Bonus:
Use new default values in env.ts (#3)